### PR TITLE
Fixes for glacier model - nans

### DIFF
--- a/src/glacier.c
+++ b/src/glacier.c
@@ -91,6 +91,7 @@ gl_volume_area(snow_data_struct **snow,
                                (ice_area_temp - ice_area_old) * exp(stepsize / BAHR_T);
 
                 // Make sure the area isn't too big
+                overflow_vol = 0.;
                 if (ice_area_new > tile_area) {
                     ice_area_new = tile_area;
                     if (options.GLACIER_OVERFLOW) {

--- a/src/output_list_utils.c
+++ b/src/output_list_utils.c
@@ -265,6 +265,7 @@ out_data_struct *create_output_list() {
   strcpy(out_data[OUT_GLQOUT_BAND].varname,"OUT_GLQOUT_BAND");
   strcpy(out_data[OUT_GLQIN_BAND].varname,"OUT_GLQIN_BAND");
   strcpy(out_data[OUT_GL_MELT_BAND].varname,"OUT_GL_MELT_BAND");
+  strcpy(out_data[OUT_GL_OVER_BAND].varname,"OUT_GL_OVER_BAND");
 
   // Set number of elements - default is 1
   for (v=0; v<N_OUTVAR_TYPES; v++) {
@@ -310,6 +311,7 @@ out_data_struct *create_output_list() {
   out_data[OUT_GLQOUT_BAND].nelem = options.SNOW_BAND;
   out_data[OUT_GLQIN_BAND].nelem = options.SNOW_BAND;
   out_data[OUT_GL_MELT_BAND].nelem = options.SNOW_BAND;
+  out_data[OUT_GL_OVER_BAND].nelem = options.SNOW_BAND;
 
   // Set aggregation method - default is to average over the interval
   for (v=0; v<N_OUTVAR_TYPES; v++) {

--- a/src/snow_melt.c
+++ b/src/snow_melt.c
@@ -103,7 +103,8 @@ snow_melt(double            latent,
         pack_glacier_we = 0.;
     }
 
-    if (snow->icedepth > 0.) {
+    if (snow->iwq > 0.) {
+        snow->icedepth = calc_snow_depth(snow->iwq, ice_density);
         surface_pack_glacier_depth = snow->depth + snow->icedepth;
         surface_pack_glacier_density = (snow->density * snow->depth +
                                         ice_density *
@@ -169,7 +170,7 @@ snow_melt(double            latent,
         snow->pack_temp = 0.0;
     }
 
-    /* Adjust ice and snow->surf_water */
+    /* Adjust surface_pack_glacier_we and snow->surf_water */
     surface_pack_glacier_we += snowfall_m;
     snow->surf_water += rainfall_m;
 
@@ -519,10 +520,10 @@ snow_melt(double            latent,
         snow->pack_water = 0.;
         snow->surf_water = 0.;
     }
+
     snow->icedepth = calc_snow_depth(snow->iwq, ice_density);
 
-    if (snow->swq <= 0.0) {
-        snow->swq = 0.0;
+    if (snow->swq == 0.) {
         snow->surf_temp = 0.0;
         snow->pack_temp = 0.0;
     }
@@ -549,11 +550,11 @@ snow_melt(double            latent,
     snow->iwqold = snow->iwq;
     snow->bn = delswe + deliwe; // glacier mass balance
 
-    melt[0] *= MMPERMETER;               /* converts back to mm */
-
     // add glacier outflow to melt and glmelt
     melt[0] += snow->gl_overflow;
     snow->glmelt += snow->gl_overflow;
+
+    melt[0] *= MMPERMETER;               /* converts back to mm */
 
     // store final values
     snow->mass_error = mass_balance_error;

--- a/src/snow_utility.c
+++ b/src/snow_utility.c
@@ -324,7 +324,7 @@ calc_snow_depth(double swq,
         depth = (double)h20_density * swq / density;
     }
     else {
-        depth = 0.0;
+        depth = 0.;
     }
 
     return(depth);
@@ -343,8 +343,12 @@ calc_cold_content(double wq,
 **********************************************************************/
 
     double cc;
-
-    cc = (double)CH_ICE * wq * temp;
+    if (wq > 0.) {
+      cc = (double) CH_ICE * wq * temp;
+    }
+    else {
+      cc = 0;
+    }
 
     return(cc);
 }
@@ -388,12 +392,11 @@ snow_to_ice(double *swq,
     double maxdens;
     double slopedens;
     
-    packswq = *swq - MAX_SURFACE_SWE;
-    packcc = calc_cold_content(packswq, *packtemp);
-    packdepth = calc_snow_depth(packswq, *density);
-    
     maxdens = 2. * (*density) - (double)NEW_SNOW_DENSITY;
     if (maxdens > SNOWICE_THRESH) {
+        packswq = *swq - MAX_SURFACE_SWE;
+        packcc = calc_cold_content(packswq, *packtemp);
+        packdepth = calc_snow_depth(packswq, *density);
         slopedens = (maxdens - (double)NEW_SNOW_DENSITY) / (packdepth);
         snowdepth = (packdepth) -
                     (((*density) - (double)NEW_SNOW_DENSITY) / slopedens);

--- a/src/solve_snow.c
+++ b/src/solve_snow.c
@@ -157,7 +157,7 @@ solve_snow(char               overstory,
     double               shortwave;
     double               vp;
     double               vpd;
-
+  
     month = dmy[rec].month;
     hour = dmy[rec].hour;
     day_in_year = dmy[rec].day_in_year;
@@ -406,7 +406,8 @@ solve_snow(char               overstory,
             energy->AlbedoUnder = *AlbedoUnder;
 
             /** Compute Snow Parameters **/
-            if (snow->swq > 0. || snow->iwq > 0.) {
+            if (snow->swq > 0.) {
+
                 /** Calculate Snow Density **/
                 if (snow->surf_temp <= 0. && (old_swq > 0. || *snowfall > 0.)) {
                     // snowpack present, compress and age density
@@ -415,14 +416,14 @@ solve_snow(char               overstory,
                 }
                 else {
                     // no snowpack present, start with new snow density
-                    if (snow->last_snow == 0) {
+                    if (snow->last_snow == 0 || snow->density <= 0.) {
                         snow->density = new_snow_density(air_temp);
                     }
                 }
 
                 // Snow to ice conversion
                 if (options.GLACIER && (soil_con->glcel == 1) && (
-                    snow->swq > MAX_SURFACE_SWE)) {
+                    snow->swq > 1.)) {
                     snow_to_ice(&snow->swq, &snow->iwq, &snow->density,
                                 &snow->pack_temp);
                 }
@@ -443,7 +444,6 @@ solve_snow(char               overstory,
                 else if (snow->MELTING && *snowfall > TraceSnow) {
                     snow->MELTING = FALSE;
                 }
-
 
                 /** Check for Thin Snowpack which only Partially Covers Grid Cell
                    exists only if not snowing and snowpack has started to melt **/

--- a/src/solve_snow.c
+++ b/src/solve_snow.c
@@ -209,7 +209,7 @@ solve_snow(char               overstory,
     (*ShortUnderIn) = shortwave;
     (*LongUnderIn) = longwave;
 
-    if (snow->swq > 0. || snow->iwq > 0. || *snowfall > 0. ||
+    if (snow->swq > 0. || snow->iwq > SMALL || *snowfall > 0. ||
         (snow->snow_canopy > 0. && overstory)) {
         /*****************************
            Snow is Present or Falling
@@ -328,7 +328,7 @@ solve_snow(char               overstory,
             energy->LongOverIn = 0.;
         }
 
-        if (snow->swq > 0.0 || *snowfall > 0.0 || snow->iwq > 0.0) {
+        if (snow->swq > 0.0 || *snowfall > 0.0 || snow->iwq > SMALL) {
             /******************************
                Snow Pack Present on Ground
             ******************************/
@@ -367,7 +367,7 @@ solve_snow(char               overstory,
                 (*AlbedoUnder) =
                     (*coverage * snow->albedo + (1. - *coverage) * BareAlbedo);
             }
-            else if ((snow->swq == 0.0) && (snow->iwq > 0.0) &&
+            else if ((snow->swq == 0.0) && (snow->iwq > SMALL) &&
                      (store_snowfall == 0.)) {
                 snow->albedo = BARE_ICE_ALBEDO;
                 (*AlbedoUnder) = snow->albedo;
@@ -461,7 +461,7 @@ solve_snow(char               overstory,
                                                         &snow->store_coverage);
                 }
                 else {
-                    if ((snow->swq > 0.) || (snow->iwq > 0.)) {
+                    if ((snow->swq > 0.) || (snow->iwq > SMALL)) {
                         snow->coverage = 1.;
                     }
                     else {
@@ -530,7 +530,7 @@ solve_snow(char               overstory,
             energy->latent_sub *= (snow->coverage + *delta_coverage);
             energy->sensible *= (snow->coverage + *delta_coverage);
 
-            if ((snow->swq == 0.) && (snow->iwq == 0.)) {
+            if ((snow->swq == 0.) && (snow->iwq <= SMALL)) {
 
                 /** Reset Snow Pack Variables after Complete Melt **/
 
@@ -550,7 +550,7 @@ solve_snow(char               overstory,
                 snow->store_snow = TRUE;
                 snow->MELTING = FALSE;
 
-                if (snow->iwq > 0) {
+                if (snow->iwq > SMALL) {
                     snow->density = ice_density;
                 }
             }

--- a/src/solve_snow.c
+++ b/src/solve_snow.c
@@ -416,14 +416,14 @@ solve_snow(char               overstory,
                 }
                 else {
                     // no snowpack present, start with new snow density
-                    if (snow->last_snow == 0 || snow->density <= 0.) {
+                    if (snow->last_snow == 0) {
                         snow->density = new_snow_density(air_temp);
                     }
                 }
 
                 // Snow to ice conversion
                 if (options.GLACIER && (soil_con->glcel == 1) && (
-                    snow->swq > 1.)) {
+                    snow->swq > SNOWICE_DEPTH)) {
                     snow_to_ice(&snow->swq, &snow->iwq, &snow->density,
                                 &snow->pack_temp);
                 }
@@ -546,6 +546,10 @@ solve_snow(char               overstory,
                 snow->snow_distrib_slope = 0.;
                 snow->store_snow = TRUE;
                 snow->MELTING = FALSE;
+
+                if (snow->iwq > 0) {
+                    snow->density = ice_density;
+                }
             }
 
             *snowfall = 0.; /* all falling snow has been added to the pack */

--- a/src/vicNl_def.h
+++ b/src/vicNl_def.h
@@ -446,6 +446,7 @@ extern char ref_veg_ref_crop[];
 #define BAHR_LAMBDA 1.375       /* V-A Scaling Exponent */
 #define BAHR_T 788940000.0      /* Time Scaling Constant ~25yrs (secs) */
 #define SNOWICE_THRESH 700.    /* kg/m3 */ 
+#define SNOWICE_DEPTH 1.    /* kg/m3 */ 
 
 /***** Define Boolean Values *****/
 #ifndef FALSE
@@ -678,11 +679,11 @@ extern char ref_veg_ref_crop[];
 // Glacier terms
 #define OUT_IWE            167
 #define OUT_IWE_BAND       168
-#define OUT_DELIWE         169 
+#define OUT_DELIWE         169
 #define OUT_GLACIER_MELT   170  /* glacier melt  [mm] (ALMA_OUTPUT: [mm/s]) */
 #define OUT_GLACIER_OVER   171  /* glacier overflow  [mm] (ALMA_OUTPUT: [mm/s]) */
-#define OUT_GL_MELT_BAND   172  /* glacier melt  [mm] (ALMA_OUTPUT: [mm/s]) */ 
-#define OUT_GL_OVER_BAND   173  /* glacier overflow  [mm] (ALMA_OUTPUT: [mm/s]) */ 
+#define OUT_GL_MELT_BAND   172  /* glacier melt  [mm] (ALMA_OUTPUT: [mm/s]) */
+#define OUT_GL_OVER_BAND   173  /* glacier overflow  [mm] (ALMA_OUTPUT: [mm/s]) */
 #define OUT_GLQOUT_BAND    174
 #define OUT_GLQIN_BAND     175
 #define OUT_BN_BAND        176


### PR DESCRIPTION
address issues creating nans when no snowpack exists over glacier and there is a positive vapor flux.

Needs a bit more testing and a code review from @bartnijssen and @tbohn (if time is available).  The code review should focus on the packing and unpacking of the glacier layer in `solve_snow.c` and `snow_melt.c`, with emphasis on the later.

#### A brief overview of the overall concepts used in this code:

The glacier ice (`snow->iwq`) is a mobile layer with a constant temperature (0 deg C) and a constant density (`917 kg/m3`).  During the call to `snow_melt.c`, the ice layer is added to the snow pack layer.  The temperature of the pack layer is adjusted to conserve cold content.  Then `snow_melt()` is run as close to normally as was possible.  After the snow pack energy balance and `melt` is calculated, I attempt to deconvolve the pack into the original snow and ice layers.  

For the most part, this has all been working just fine with a few issues here and there.  Specifically, the `vapor_flux` has given me a number of problems and the most recent issue was mostly caused by very thin glacier ice with no snow pack.  I think the partitioning of the snow/ice layers at the end of `snow_melt.c` is pretty ugly so I would appreciate any thoughts on how to simplify that section.