### PR TITLE
Successful compilation of feature/cesm_travis

### DIFF
--- a/vic/drivers/cesm/Makefile
+++ b/vic/drivers/cesm/Makefile
@@ -74,7 +74,7 @@ INCLUDES = -I ${DRIVERPATH}/include -I ${VICPATH}/include -I ${SHAREDPATH}/inclu
 LIBRARY = -lm -L${NETCDFPATH}/lib -lnetcdf -L${MPIPATH}/lib -lmpi
 
 # Uncomment to include debugging information
-CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra
+CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -fPIC
 #LIBRARY = -lm
 
 # Uncomment to include execution profiling information

--- a/vic/drivers/cesm/include/vic_driver_cesm.h
+++ b/vic/drivers/cesm/include/vic_driver_cesm.h
@@ -28,8 +28,6 @@
 #define VIC_DRIVER_CESM_H
 
 #include <stdbool.h>
-#include <netcdf.h>
-#include <stdio.h>
 #include <vic_mpi.h>
 #include <netcdf.h>
 #include <vic_driver_shared.h>


### PR DESCRIPTION
`<netcdf.h>` was included twice in `vic_driver_cesm.h` (main source of error)
`-fPIC` was added to `CFLAGS` (needed for successful compilation of library)
`<stdio.h>` not needed in `vic_driver_cesm.h` (only include files that are required)