### PR TITLE
Fixed NMONTHS frequncy

### DIFF
--- a/vic/drivers/classic/src/parse_output_info.c
+++ b/vic/drivers/classic/src/parse_output_info.c
@@ -137,9 +137,7 @@ parse_output_info(FILE           *gp,
                         strpdmy(freq_value_str, "%Y-%m-%d", &freq_dmy);
                         // set the alarm
                         set_alarm(dmy_current, freq, &freq_dmy,
-                                  (&(*streams)[streamnum].agg_alarm),
-                                  - (double) 1 /
-                                  (double) global_param.model_steps_per_day);
+                                  (&(*streams)[streamnum].agg_alarm));
                     }
                     else {
                         if (found != 2) {
@@ -152,9 +150,7 @@ parse_output_info(FILE           *gp,
                         }
                         // set the alarm
                         set_alarm(dmy_current, freq, &freq_n,
-                                  (&(*streams)[streamnum].agg_alarm),
-                                  - (double) 1 /
-                                  (double) global_param.model_steps_per_day);
+                                  (&(*streams)[streamnum].agg_alarm));
                     }
                 }
                 else if (strcasecmp("COMPRESS", optstr) == 0) {

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -196,9 +196,7 @@ main(int   argc,
                 n = streams[streamnum].agg_alarm.n;
                 set_alarm(&(dmy[0]), streams[streamnum].agg_alarm.freq,
                           &n,
-                          &(streams[streamnum].agg_alarm),
-                          - (double) 1 /
-                          (double) global_param.model_steps_per_day);
+                          &(streams[streamnum].agg_alarm));
             }
 
             /** Read Elevation Band Data if Used **/

--- a/vic/drivers/shared_all/include/vic_driver_shared_all.h
+++ b/vic/drivers/shared_all/include/vic_driver_shared_all.h
@@ -696,14 +696,14 @@ void print_version(char *);
 void print_usage(char *);
 double q_to_vp(double q, double p);
 bool raise_alarm(alarm_struct *alarm, dmy_struct *dmy_current);
-void reset_alarm(alarm_struct *alarm, dmy_struct *dmy_current, double offset);
+void reset_alarm(alarm_struct *alarm, dmy_struct *dmy_current);
 void reset_stream(stream_struct *stream, dmy_struct *dmy_current);
 void set_output_var(stream_struct *stream, char *varname, size_t varnum,
                     char *format, unsigned short int type, double mult,
                     unsigned short int aggtype);
 unsigned int get_default_outvar_aggtype(unsigned int varid);
 void set_alarm(dmy_struct *dmy_current, unsigned int freq, void *value,
-               alarm_struct *alarm, double offset);
+               alarm_struct *alarm);
 void set_output_defaults(stream_struct **output_streams,
                          dmy_struct     *dmy_current,
                          unsigned short  default_file_format);

--- a/vic/drivers/shared_all/src/alarms.c
+++ b/vic/drivers/shared_all/src/alarms.c
@@ -58,11 +58,11 @@ reset_alarm(alarm_struct *alarm,
         // beginning of the last timestep of a month. This will cause problem
         // because of different number of days in each month. This shift here
         // will avoid this problem.
-        // NOTE: if a simulation starts not from the beginning of a month,
+        // NOTE: if a simulation does not start from the beginning of a month,
         // there might be a problem if startday > 28 !!!
         
         // Shift forward by one time step
-        offset = global_param.dt / 3600 / 24;
+        offset = global_param.dt / (double) SEC_PER_DAY;
         current = date2num(global_param.time_origin_num, dmy_current, 0,
                            global_param.calendar, TIME_UNITS_DAYS);
         current += offset;

--- a/vic/drivers/shared_all/src/alarms.c
+++ b/vic/drivers/shared_all/src/alarms.c
@@ -32,14 +32,15 @@
  *****************************************************************************/
 void
 reset_alarm(alarm_struct *alarm,
-            dmy_struct   *dmy_current,
-            double        offset)
+            dmy_struct   *dmy_current)
 {
     extern global_param_struct global_param;
 
     double                     delta;
     double                     current;
     double                     next;
+    double                     offset;
+    dmy_struct                 dmy_current_offset;
 
     alarm->count = 0;
 
@@ -47,11 +48,44 @@ reset_alarm(alarm_struct *alarm,
         (alarm->freq == FREQ_DATE) || (alarm->freq == FREQ_END)) {
         ;  // Do nothing, already set
     }
+    else if (alarm->freq == FREQ_NMONTHS) {
+        // If aggregation frequency is NMONTHS, then first shift dmy_current
+        // forward for one timestep, advance month(s), then shift backward for
+        // one timestep. This is to avoid the following issue: the most common
+        // usage of AGGFREQ = NMONTHS is to start a simulation from 00:00:00
+        // of the first day of a certain month; since dmy_current is
+        // "timestep-beginning", the aggregation window timestamp will be the
+        // beginning of the last timestep of a month. This will cause problem
+        // because of different number of days in each month. This shift here
+        // will avoid this problem.
+        // NOTE: if a simulation starts not from the beginning of a month,
+        // there might be a problem if startday > 28 !!!
+        
+        // Shift forward by one time step
+        offset = global_param.dt / 3600 / 24;
+        current = date2num(global_param.time_origin_num, dmy_current, 0,
+                           global_param.calendar, TIME_UNITS_DAYS);
+        current += offset;
+        num2date(global_param.time_origin_num, current, 0,
+                 global_param.calendar, TIME_UNITS_DAYS,
+                 &dmy_current_offset);
+        // Advance
+        delta = time_delta(&dmy_current_offset, alarm->freq, alarm->n);
+        current = date2num(global_param.time_origin_num, &dmy_current_offset,
+                           0, global_param.calendar, TIME_UNITS_DAYS);
+        next = delta + current;
+        // Shift backward by one time step
+        next -= offset;
+        num2date(global_param.time_origin_num, next, 0,
+                 global_param.calendar, TIME_UNITS_DAYS,
+                 &(alarm->next_dmy));
+    }
     else {
+        // If other frequency types, directly advance without shifting
         delta = time_delta(dmy_current, alarm->freq, alarm->n);
         current = date2num(global_param.time_origin_num, dmy_current, 0,
                            global_param.calendar, TIME_UNITS_DAYS);
-        next = delta + current + offset;
+        next = delta + current;
         num2date(global_param.time_origin_num, next, 0,
                  global_param.calendar, TIME_UNITS_DAYS,
                  &(alarm->next_dmy));
@@ -82,10 +116,12 @@ void
 set_alarm(dmy_struct   *dmy_current,
           unsigned int  freq,
           void         *value,
-          alarm_struct *alarm,
-          double        offset)
+          alarm_struct *alarm)
 {
     extern global_param_struct global_param;
+    dmy_struct                 dmy_current_offset;
+    double                     delta;
+    double                     current;
 
     alarm->count = 0;
     alarm->freq = freq;
@@ -118,7 +154,27 @@ set_alarm(dmy_struct   *dmy_current,
     }
 
     // Set alarm->next via reset_alarm
-    reset_alarm(alarm, dmy_current, offset);
+    // set_alarm only gets called in the initialization step. Therefore,
+    // shift dmy_current to one timestep earlier before advancing for one
+    // aggregation window, because dmy_current does not change after running
+    // the first timestep (so it would still be the beginning of the first
+    // timestep)
+    if ((alarm->freq == FREQ_NEVER) || (alarm->freq == FREQ_NSTEPS) ||
+        (alarm->freq == FREQ_DATE) || (alarm->freq == FREQ_END)) {
+        ;  // Do nothing, already set
+    }
+    else {
+        delta = time_delta(dmy_current, FREQ_NSECONDS,
+                           (int) global_param.dt);
+        current = date2num(global_param.time_origin_num, dmy_current, 0,
+                           global_param.calendar, TIME_UNITS_DAYS);
+        current -= delta;
+        num2date(global_param.time_origin_num, current, 0,
+                 global_param.calendar, TIME_UNITS_DAYS,
+                 &dmy_current_offset);
+    }
+    // set alarm->next
+    reset_alarm(alarm, &dmy_current_offset);
 
     // Set subdaily attribute
     if (((freq == FREQ_NSTEPS) &&

--- a/vic/drivers/shared_all/src/set_output_defaults.c
+++ b/vic/drivers/shared_all/src/set_output_defaults.c
@@ -107,8 +107,7 @@ set_output_defaults(stream_struct **streams,
     int                  default_freq_n = 1;
 
 
-    set_alarm(dmy_current, FREQ_NDAYS, &default_freq_n, &default_alarm,
-              - (double ) 1 / (double) global_param.model_steps_per_day);
+    set_alarm(dmy_current, FREQ_NDAYS, &default_freq_n, &default_alarm);
 
     for (streamnum = 0; streamnum < options.Noutstreams; streamnum++) {
         (*streams)[streamnum].agg_alarm = default_alarm;

--- a/vic/drivers/shared_all/src/vic_history.c
+++ b/vic/drivers/shared_all/src/vic_history.c
@@ -87,10 +87,10 @@ setup_stream(stream_struct *stream,
     dmy_junk.dayseconds = 0;
 
     // Set default agg alarm
-    set_alarm(&dmy_junk, FREQ_NDAYS, &default_n, &(stream->agg_alarm), 0.);
+    set_alarm(&dmy_junk, FREQ_NDAYS, &default_n, &(stream->agg_alarm));
 
     // Set default write alarm
-    set_alarm(&dmy_junk, FREQ_END, &default_n, &(stream->write_alarm), 0.);
+    set_alarm(&dmy_junk, FREQ_END, &default_n, &(stream->write_alarm));
 
     // Allocate stream members of shape [nvars]
     stream->varid = calloc(nvars, sizeof(*(stream->varid)));
@@ -218,7 +218,7 @@ reset_stream(stream_struct *stream,
     size_t                 varid;
 
     // Reset alarm to next agg period
-    reset_alarm(&(stream->agg_alarm), dmy_current, 0.);
+    reset_alarm(&(stream->agg_alarm), dmy_current);
 
     // Set aggdata to zero
     for (i = 0; i < stream->ngridcells; i++) {

--- a/vic/drivers/shared_image/src/parse_output_info.c
+++ b/vic/drivers/shared_image/src/parse_output_info.c
@@ -112,9 +112,7 @@ parse_output_info(FILE           *gp,
                     strpdmy(freq_value_str, "%Y-%m-%d", &freq_dmy);
                     // set the alarm
                     set_alarm(dmy_current, freq, &freq_dmy,
-                              (&(*streams)[streamnum].agg_alarm),
-                              - (double) 1 /
-                              (double) global_param.model_steps_per_day);
+                              (&(*streams)[streamnum].agg_alarm));
                 }
                 else {
                     if (found != 2) {
@@ -127,9 +125,7 @@ parse_output_info(FILE           *gp,
                     }
                     // set the alarm
                     set_alarm(dmy_current, freq, &freq_n,
-                              (&(*streams)[streamnum].agg_alarm),
-                              - (double) 1 /
-                              (double) global_param.model_steps_per_day);
+                              (&(*streams)[streamnum].agg_alarm));
                 }
             }
             else if (strcasecmp("HISTFREQ", optstr) == 0) {
@@ -156,9 +152,7 @@ parse_output_info(FILE           *gp,
                     strpdmy(freq_value_str, "%Y-%m-%d", &freq_dmy);
                     // set the alarm
                     set_alarm(dmy_current, freq, &freq_dmy,
-                              (&(*streams)[streamnum].write_alarm),
-                              - (double) 1 /
-                              (double) global_param.model_steps_per_day);
+                              (&(*streams)[streamnum].write_alarm));
                 }
                 else {
                     if (found != 2) {
@@ -171,9 +165,7 @@ parse_output_info(FILE           *gp,
                     }
                     // set the alarm
                     set_alarm(dmy_current, freq, &freq_n,
-                              (&(*streams)[streamnum].write_alarm),
-                               - (double )1 /
-                               (double) global_param.model_steps_per_day);
+                              (&(*streams)[streamnum].write_alarm));
                 }
             }
             else if (strcasecmp("COMPRESS", optstr) == 0) {

--- a/vic/drivers/shared_image/src/vic_write.c
+++ b/vic/drivers/shared_image/src/vic_write.c
@@ -230,7 +230,7 @@ vic_write(stream_struct  *stream,
             check_nc_status(status, "Error closing history file");
             nc_hist_file->open = false;
         }
-        reset_alarm(&(stream->write_alarm), dmy_current, 0);
+        reset_alarm(&(stream->write_alarm), dmy_current);
     }
     else {
         // Force sync with disk (GH:#596)


### PR DESCRIPTION
Now `NMONTHS` frequency works for both `AGGFREQ` and `HISTFREQ`. Code changes:
- In `set_alarm` (which is for initializing alarm), shift the simulation start time earlier for one timestep before advance to the first alarm time (this is because `dmy_current` does not change after running the first timestep, since we are using "timestep-beginning" timestamp)
- For `NMONTHS` frequency, we advance the alarm in the following way: 1) shift the current time forward (i.e., later) by one timestep; 2) advance by n months via `time_delta` function; 3) shift the advanced alarm time back by one timestep. The purpose of doing so is to avoid issues with un-uniform number of days in each month when the simulation starts at the beginning of a certain month.
